### PR TITLE
Add clippy

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,3 +4,4 @@ version = "0.1.0"
 authors = ["J/A <archer884@gmail.com>"]
 
 [dependencies]
+clippy = "*"


### PR DESCRIPTION
Adds clippy as a dependency. Nightly not required, but cargo-clippy is.
